### PR TITLE
Refactor imagequality module to operate on raw luminance buffers

### DIFF
--- a/app/src/main/java/com/rochias/clarity/processing/ImagePreparation.kt
+++ b/app/src/main/java/com/rochias/clarity/processing/ImagePreparation.kt
@@ -1,0 +1,43 @@
+package com.rochias.clarity.processing
+
+import android.graphics.Bitmap
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+data class LuminanceImage(
+    val width: Int,
+    val height: Int,
+    val luminance: ByteArray
+)
+
+fun extractLuminance(bitmap: Bitmap, maxDimension: Int = 1024): LuminanceImage {
+    val processed = bitmap.downscale(maxDimension)
+    val width = processed.width
+    val height = processed.height
+    val pixels = IntArray(width * height)
+    processed.getPixels(pixels, 0, width, 0, 0, width, height)
+    val buffer = ByteArray(pixels.size)
+    for (index in pixels.indices) {
+        val pixel = pixels[index]
+        val r = (pixel shr 16) and 0xFF
+        val g = (pixel shr 8) and 0xFF
+        val b = pixel and 0xFF
+        val value = ((77 * r + 150 * g + 29 * b) shr 8).coerceIn(0, 255)
+        buffer[index] = value.toByte()
+    }
+    if (processed !== bitmap) {
+        processed.recycle()
+    }
+    return LuminanceImage(width, height, buffer)
+}
+
+private fun Bitmap.downscale(maxDimension: Int): Bitmap {
+    val largest = max(width, height)
+    if (largest <= maxDimension) {
+        return this
+    }
+    val scale = maxDimension.toFloat() / largest.toFloat()
+    val targetWidth = (width * scale).roundToInt().coerceAtLeast(1)
+    val targetHeight = (height * scale).roundToInt().coerceAtLeast(1)
+    return Bitmap.createScaledBitmap(this, targetWidth, targetHeight, true)
+}

--- a/app/src/main/java/com/rochias/clarity/ui/CompareScreen.kt
+++ b/app/src/main/java/com/rochias/clarity/ui/CompareScreen.kt
@@ -37,6 +37,7 @@ import com.rochias.clarity.camera.CameraPreview
 import com.rochias.clarity.camera.CameraCaptureState
 import com.rochias.clarity.camera.rememberCameraCaptureState
 import com.rochias.clarity.iq.Clarity
+import com.rochias.clarity.processing.extractLuminance
 import kotlinx.coroutines.launch
 
 @Composable
@@ -238,8 +239,9 @@ private suspend fun captureImage(
 }
 
 private fun evaluateClarity(bitmap: Bitmap): ClarityScores {
-    val laplacian = Clarity.varianceOfLaplacian(bitmap)
-    val tenengrad = Clarity.tenengrad(bitmap)
+    val image = extractLuminance(bitmap)
+    val laplacian = Clarity.varianceOfLaplacian(image.width, image.height, image.luminance)
+    val tenengrad = Clarity.tenengrad(image.width, image.height, image.luminance)
     return ClarityScores(laplacian, tenengrad)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.android.library") version "8.13.0" apply false
     id("org.jetbrains.kotlin.android") version "2.1.20" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.20" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.1.20" apply false
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -2,8 +2,8 @@
 set -e
 
 APP_HOME=$(cd "$(dirname "$0")" && pwd -P)
-DISTRIBUTION_URL="https://services.gradle.org/distributions/gradle-8.10.2-bin.zip"
-DIST_NAME="gradle-8.10.2"
+DISTRIBUTION_URL="https://services.gradle.org/distributions/gradle-8.13-bin.zip"
+DIST_NAME="gradle-8.13"
 WRAPPER_DIR="$APP_HOME/gradle/wrapper"
 DIST_DIR="$WRAPPER_DIR/$DIST_NAME"
 GRADLE_CMD="$DIST_DIR/bin/gradle"

--- a/imagequality/build.gradle.kts
+++ b/imagequality/build.gradle.kts
@@ -1,26 +1,12 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.jvm")
 }
 
-android {
-    namespace = "com.photo.clarity.iq"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
     }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
-
-dependencies {
-    implementation("androidx.core:core-ktx:1.13.1")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,14 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = "photo-clarity"
 include(":app", ":imagequality")


### PR DESCRIPTION
## Summary
- remove Bitmap dependencies from the Clarity algorithms and expose overloads that accept raw grayscale buffers
- add Android-side preprocessing utilities to downscale bitmaps and extract luminance arrays before invoking the pure Kotlin logic
- convert the imagequality module to a Kotlin/JVM project and update the Gradle wrapper/toolchain configuration

## Testing
- ./gradlew :imagequality:test --console=plain
- ./gradlew :app:assembleDebug --console=plain *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de2380f1dc832e8c70cd8cc8f6420c