### PR TITLE
feat: persist camera captures to gallery

### DIFF
--- a/app/src/main/java/com/rochias/clarity/camera/CameraCapture.kt
+++ b/app/src/main/java/com/rochias/clarity/camera/CameraCapture.kt
@@ -1,5 +1,6 @@
 package com.rochias.clarity.camera
 
+import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -7,6 +8,10 @@ import android.graphics.ImageFormat
 import android.graphics.Matrix
 import android.graphics.Rect
 import android.graphics.YuvImage
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.ImageProxy
 import androidx.camera.view.LifecycleCameraController
@@ -21,27 +26,33 @@ import androidx.core.content.ContextCompat
 import androidx.camera.view.PreviewView
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class CameraCaptureState internal constructor(
     private val context: Context,
     val controller: LifecycleCameraController
 ) {
-    suspend fun captureBitmap(): Bitmap? = suspendCancellableCoroutine { continuation ->
+    suspend fun captureBitmap(): CapturedImage? = suspendCancellableCoroutine { continuation ->
         controller.takePicture(
             ContextCompat.getMainExecutor(context),
             object : androidx.camera.core.ImageCapture.OnImageCapturedCallback() {
                 override fun onCaptureSuccess(image: ImageProxy) {
-                    runCatching {
+                    val result = runCatching {
                         val rotation = image.imageInfo.rotationDegrees
-                        val bitmap = image.toBitmap()?.let { it.rotate(rotation) }
-                        image.close()
-                        continuation.resume(bitmap)
-                    }.onFailure {
-                        image.close()
-                        continuation.resume(null)
+                        val bitmap = image.toBitmap()?.let { it.rotate(rotation) } ?: throw IOException("Unable to process image")
+                        val uri = context.saveBitmapToClarity(bitmap)
+                        CapturedImage(uri, bitmap)
                     }
+                    image.close()
+                    result.onSuccess { continuation.resume(it) }
+                        .onFailure { continuation.resumeWithException(it) }
                 }
 
                 override fun onError(exception: ImageCaptureException) {
@@ -51,6 +62,11 @@ class CameraCaptureState internal constructor(
         )
     }
 }
+
+data class CapturedImage(
+    val uri: Uri,
+    val bitmap: Bitmap
+)
 
 @Composable
 fun rememberCameraCaptureState(): CameraCaptureState {
@@ -109,4 +125,42 @@ private fun Bitmap.rotate(degrees: Int): Bitmap {
     val matrix = Matrix()
     matrix.postRotate(degrees.toFloat())
     return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
+}
+
+private fun Context.saveBitmapToClarity(bitmap: Bitmap): Uri {
+    val fileName = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+    val name = "Clarity_$fileName.jpg"
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, name)
+            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+            put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + File.separator + "Clarity")
+        }
+        val resolver = contentResolver
+        val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values) ?: throw IOException("Unable to create media entry")
+        try {
+            resolver.openOutputStream(uri)?.use { stream ->
+                if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, stream)) {
+                    throw IOException("Unable to save image")
+                }
+            } ?: throw IOException("Unable to open output stream")
+            uri
+        } catch (error: Throwable) {
+            resolver.delete(uri, null, null)
+            throw error
+        }
+    } else {
+        val pictures = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+        val clarityDir = File(pictures, "Clarity")
+        if (!clarityDir.exists() && !clarityDir.mkdirs()) {
+            throw IOException("Unable to access storage")
+        }
+        val file = File(clarityDir, name)
+        FileOutputStream(file).use { stream ->
+            if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, stream)) {
+                throw IOException("Unable to save image")
+            }
+        }
+        Uri.fromFile(file)
+    }
 }


### PR DESCRIPTION
## Summary
- save captured photos to Pictures/Clarity with rotation handling
- return saved file URIs alongside previews to the comparison screen
- request legacy storage permission before capture and route save errors to the UI

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6788e6c4832eb866fa91c684bf4b