### PR TITLE
feat: persist captured photo URIs across lifecycle

### DIFF
--- a/app/src/main/java/com/rochias/clarity/MainActivity.kt
+++ b/app/src/main/java/com/rochias/clarity/MainActivity.kt
@@ -1,6 +1,12 @@
 package com.rochias.clarity
 
 import android.Manifest
+import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -16,17 +22,27 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
+import com.rochias.clarity.camera.rememberCameraCaptureState
+import com.rochias.clarity.iq.Clarity
+import com.rochias.clarity.iq.ClarityEvaluation
+import com.rochias.clarity.iq.ClarityMethod
+import com.rochias.clarity.processing.extractLuminance
 import com.rochias.clarity.ui.CompareScreen
+import java.io.File
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,7 +61,7 @@ class MainActivity : ComponentActivity() {
 private fun CameraPermissionScreen() {
     val context = LocalContext.current
     val permission = Manifest.permission.CAMERA
-    var hasPermission by remember {
+    var hasPermission by rememberSaveable {
         mutableStateOf(
             ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
         )
@@ -59,12 +75,132 @@ private fun CameraPermissionScreen() {
         }
     }
     if (hasPermission) {
-        CompareScreen()
+        ComparisonHost()
     } else {
         PermissionRequest(onRequest = {
             launcher.launch(permission)
         })
     }
+}
+
+@Composable
+private fun ComparisonHost() {
+    val context = LocalContext.current
+    val cameraState = rememberCameraCaptureState()
+    val scope = rememberCoroutineScope()
+    val storagePermission = Manifest.permission.WRITE_EXTERNAL_STORAGE
+    val requiresStoragePermission = remember { Build.VERSION.SDK_INT < Build.VERSION_CODES.Q }
+    var hasStoragePermission by rememberSaveable {
+        mutableStateOf(
+            !requiresStoragePermission || ContextCompat.checkSelfPermission(
+                context,
+                storagePermission
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    var firstPhotoUri by rememberSaveable { mutableStateOf<String?>(null) }
+    var secondPhotoUri by rememberSaveable { mutableStateOf<String?>(null) }
+    var firstClarity by rememberSaveable(stateSaver = clarityEvaluationSaver) {
+        mutableStateOf<ClarityEvaluation?>(null)
+    }
+    var secondClarity by rememberSaveable(stateSaver = clarityEvaluationSaver) {
+        mutableStateOf<ClarityEvaluation?>(null)
+    }
+    var activeSlot by rememberSaveable { mutableStateOf<PhotoSlot?>(null) }
+    var compareRequested by rememberSaveable { mutableStateOf(false) }
+    var errorMessage by rememberSaveable { mutableStateOf<String?>(null) }
+    val storagePermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        hasStoragePermission = granted
+        if (!granted) {
+            errorMessage = "Autorisation de stockage requise pour enregistrer les images"
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            activeSlot = null
+        }
+    }
+
+    fun clearPhoto(slot: PhotoSlot) {
+        val uriToClear = when (slot) {
+            PhotoSlot.FIRST -> firstPhotoUri
+            PhotoSlot.SECOND -> secondPhotoUri
+        }
+        val deletionFailed = uriToClear != null && !deletePersistedUri(context, uriToClear)
+        when (slot) {
+            PhotoSlot.FIRST -> {
+                firstPhotoUri = null
+                firstClarity = null
+            }
+            PhotoSlot.SECOND -> {
+                secondPhotoUri = null
+                secondClarity = null
+            }
+        }
+        compareRequested = false
+        if (deletionFailed) {
+            errorMessage = "Impossible de supprimer l'image sélectionnée"
+        }
+    }
+
+    val canCompare = firstPhotoUri != null && secondPhotoUri != null && firstClarity != null && secondClarity != null
+
+    fun handleCapture(slot: PhotoSlot) {
+        if (activeSlot != null) return
+        if (requiresStoragePermission && !hasStoragePermission) {
+            storagePermissionLauncher.launch(storagePermission)
+            return
+        }
+        errorMessage = null
+        scope.launch {
+            activeSlot = slot
+            runCatching {
+                cameraState.captureBitmap()
+            }.onSuccess { capture ->
+                if (capture == null) {
+                    errorMessage = "Impossible de capturer l'image"
+                } else {
+                    val evaluation = evaluateClarity(capture.bitmap)
+                    when (slot) {
+                        PhotoSlot.FIRST -> {
+                            firstPhotoUri = capture.uri.toString()
+                            firstClarity = evaluation
+                        }
+                        PhotoSlot.SECOND -> {
+                            secondPhotoUri = capture.uri.toString()
+                            secondClarity = evaluation
+                        }
+                    }
+                    compareRequested = false
+                    capture.bitmap.recycle()
+                }
+            }.onFailure {
+                errorMessage = it.message ?: "Échec de la capture de l'image"
+            }
+            activeSlot = null
+        }
+    }
+
+    CompareScreen(
+        cameraState = cameraState,
+        firstPhotoUri = firstPhotoUri,
+        secondPhotoUri = secondPhotoUri,
+        firstClarity = firstClarity,
+        secondClarity = secondClarity,
+        isCapturing = activeSlot != null,
+        canCompare = canCompare,
+        compareRequested = compareRequested,
+        errorMessage = errorMessage,
+        onCapture = { handleCapture(it) },
+        onClear = { clearPhoto(it) },
+        onCompare = {
+            if (canCompare) {
+                compareRequested = true
+            }
+        },
+        onErrorDismiss = { errorMessage = null }
+    )
 }
 
 @Composable
@@ -75,9 +211,9 @@ private fun PermissionRequest(onRequest: () -> Unit) {
             .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text(text = "Camera permission is required to capture images", style = MaterialTheme.typography.titleMedium)
+        Text(text = "La permission caméra est nécessaire pour capturer des images", style = MaterialTheme.typography.titleMedium)
         Button(onClick = onRequest) {
-            Text(text = "Grant Permission")
+            Text(text = "Autoriser")
         }
     }
 }
@@ -88,4 +224,36 @@ private fun PermissionRequestPreview() {
     MaterialTheme {
         PermissionRequest(onRequest = {})
     }
+}
+
+private val clarityEvaluationSaver = Saver<ClarityEvaluation?, List<Any?>>(
+    save = { value ->
+        value?.let { listOf(it.score, it.method.name, it.laplacianScore, it.tenengradScore) }
+    },
+    restore = { value ->
+        value?.let {
+            ClarityEvaluation(
+                score = it[0] as Double,
+                method = ClarityMethod.valueOf(it[1] as String),
+                laplacianScore = it[2] as Double,
+                tenengradScore = it[3] as Double?
+            )
+        }
+    }
+)
+
+private fun evaluateClarity(bitmap: Bitmap): ClarityEvaluation {
+    val image = extractLuminance(bitmap)
+    return Clarity.clarityScore(image.width, image.height, image.luminance)
+}
+
+private fun deletePersistedUri(context: Context, uriString: String): Boolean {
+    return runCatching {
+        val uri = Uri.parse(uriString)
+        when (uri.scheme) {
+            ContentResolver.SCHEME_CONTENT -> context.contentResolver.delete(uri, null, null) > 0
+            ContentResolver.SCHEME_FILE -> uri.path?.let { File(it).delete() } ?: false
+            else -> context.contentResolver.delete(uri, null, null) > 0
+        }
+    }.getOrElse { false }
 }

--- a/app/src/main/java/com/rochias/clarity/PhotoSlot.kt
+++ b/app/src/main/java/com/rochias/clarity/PhotoSlot.kt
@@ -1,0 +1,6 @@
+package com.rochias.clarity
+
+enum class PhotoSlot {
+    FIRST,
+    SECOND
+}

--- a/app/src/main/java/com/rochias/clarity/ui/CompareScreen.kt
+++ b/app/src/main/java/com/rochias/clarity/ui/CompareScreen.kt
@@ -1,12 +1,8 @@
 package com.rochias.clarity.ui
 
-import android.Manifest
-import android.content.pm.PackageManager
+import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
-import android.os.Build
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,57 +21,42 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
+import com.rochias.clarity.PhotoSlot
 import com.rochias.clarity.camera.CameraPreview
 import com.rochias.clarity.camera.CameraCaptureState
-import com.rochias.clarity.camera.rememberCameraCaptureState
-import com.rochias.clarity.iq.Clarity
 import com.rochias.clarity.iq.ClarityEvaluation
 import com.rochias.clarity.iq.ClarityMethod
-import com.rochias.clarity.processing.extractLuminance
-import kotlinx.coroutines.launch
+import android.graphics.BitmapFactory
 
 @Composable
-fun CompareScreen(modifier: Modifier = Modifier) {
-    val cameraState = rememberCameraCaptureState()
-    val scope = rememberCoroutineScope()
-    val context = LocalContext.current
-    val storagePermission = Manifest.permission.WRITE_EXTERNAL_STORAGE
-    val requiresStoragePermission = remember { Build.VERSION.SDK_INT < Build.VERSION_CODES.Q }
-    var hasStoragePermission by remember {
-        mutableStateOf(
-            !requiresStoragePermission || ContextCompat.checkSelfPermission(context, storagePermission) == PackageManager.PERMISSION_GRANTED
-        )
-    }
-    var errorMessage by remember { mutableStateOf<String?>(null) }
-    val storagePermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-        hasStoragePermission = granted
-        if (!granted) {
-            errorMessage = "Storage permission is required to save images"
-        }
-    }
-    var firstBitmap by remember { mutableStateOf<Bitmap?>(null) }
-    var secondBitmap by remember { mutableStateOf<Bitmap?>(null) }
-    var firstImageUri by remember { mutableStateOf<Uri?>(null) }
-    var secondImageUri by remember { mutableStateOf<Uri?>(null) }
-    var firstClarity by remember { mutableStateOf<ClarityEvaluation?>(null) }
-    var secondClarity by remember { mutableStateOf<ClarityEvaluation?>(null) }
-    var isCapturing by remember { mutableStateOf(false) }
+fun CompareScreen(
+    cameraState: CameraCaptureState,
+    firstPhotoUri: String?,
+    secondPhotoUri: String?,
+    firstClarity: ClarityEvaluation?,
+    secondClarity: ClarityEvaluation?,
+    isCapturing: Boolean,
+    canCompare: Boolean,
+    compareRequested: Boolean,
+    errorMessage: String?,
+    onCapture: (PhotoSlot) -> Unit,
+    onClear: (PhotoSlot) -> Unit,
+    onCompare: () -> Unit,
+    onErrorDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -83,56 +64,52 @@ fun CompareScreen(modifier: Modifier = Modifier) {
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        CameraSection(cameraState = cameraState)
-        CaptureControls(
-            isCapturing = isCapturing,
-            onCaptureFirst = {
-                if (requiresStoragePermission && !hasStoragePermission) {
-                    storagePermissionLauncher.launch(storagePermission)
-                } else {
-                    scope.launch {
-                        captureImage(cameraState, onResult = { uri, bitmap ->
-                            firstImageUri = uri
-                            firstBitmap = bitmap
-                            firstClarity = evaluateClarity(bitmap)
-                        }, onError = { message ->
-                            errorMessage = message
-                        }, onStateChange = { busy ->
-                            isCapturing = busy
-                        })
-                    }
-                }
-            },
-            onCaptureSecond = {
-                if (requiresStoragePermission && !hasStoragePermission) {
-                    storagePermissionLauncher.launch(storagePermission)
-                } else {
-                    scope.launch {
-                        captureImage(cameraState, onResult = { uri, bitmap ->
-                            secondImageUri = uri
-                            secondBitmap = bitmap
-                            secondClarity = evaluateClarity(bitmap)
-                        }, onError = { message ->
-                            errorMessage = message
-                        }, onStateChange = { busy ->
-                            isCapturing = busy
-                        })
-                    }
-                }
-            }
-        )
-        ResultSection(firstClarity, secondClarity, firstBitmap, secondBitmap)
-        ErrorMessage(errorMessage)
-        LaunchedEffect(firstBitmap, secondBitmap, firstImageUri, secondImageUri) {
-            if (errorMessage != null) {
-                errorMessage = null
-            }
+        CameraSection(cameraState = cameraState, isCapturing = isCapturing)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            PhotoCard(
+                modifier = Modifier.weight(1f),
+                title = "Photo A",
+                uriString = firstPhotoUri,
+                contentDescription = "Première photo",
+                onCapture = { onCapture(PhotoSlot.FIRST) },
+                onClear = { onClear(PhotoSlot.FIRST) },
+                isCapturing = isCapturing
+            )
+            PhotoCard(
+                modifier = Modifier.weight(1f),
+                title = "Photo B",
+                uriString = secondPhotoUri,
+                contentDescription = "Deuxième photo",
+                onCapture = { onCapture(PhotoSlot.SECOND) },
+                onClear = { onClear(PhotoSlot.SECOND) },
+                isCapturing = isCapturing
+            )
         }
+        Button(
+            modifier = Modifier.fillMaxWidth(),
+            enabled = canCompare && !isCapturing,
+            onClick = onCompare,
+            contentPadding = PaddingValues(vertical = 16.dp)
+        ) {
+            Text(text = "Comparer")
+        }
+        if (compareRequested && canCompare && firstClarity != null && secondClarity != null) {
+            ResultSection(
+                firstScores = firstClarity,
+                secondScores = secondClarity,
+                firstPhotoUri = firstPhotoUri,
+                secondPhotoUri = secondPhotoUri
+            )
+        }
+        ErrorMessage(errorMessage = errorMessage, onDismiss = onErrorDismiss)
     }
 }
 
 @Composable
-private fun CameraSection(cameraState: CameraCaptureState) {
+private fun CameraSection(cameraState: CameraCaptureState, isCapturing: Boolean) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
@@ -143,45 +120,63 @@ private fun CameraSection(cameraState: CameraCaptureState) {
             .height(320.dp)
         ) {
             CameraPreview(state = cameraState, modifier = Modifier.fillMaxSize())
+            if (isCapturing) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
         }
     }
 }
 
 @Composable
-private fun CaptureControls(
-    isCapturing: Boolean,
-    onCaptureFirst: () -> Unit,
-    onCaptureSecond: () -> Unit
+private fun PhotoCard(
+    modifier: Modifier,
+    title: String,
+    uriString: String?,
+    contentDescription: String,
+    onCapture: () -> Unit,
+    onClear: () -> Unit,
+    isCapturing: Boolean
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
-        Button(
-            modifier = Modifier.weight(1f),
-            enabled = !isCapturing,
-            onClick = onCaptureFirst,
-            contentPadding = PaddingValues(vertical = 16.dp)
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text(text = "Capture First")
-        }
-        Button(
-            modifier = Modifier.weight(1f),
-            enabled = !isCapturing,
-            onClick = onCaptureSecond,
-            contentPadding = PaddingValues(vertical = 16.dp)
-        ) {
-            Text(text = "Capture Second")
-        }
-    }
-    if (isCapturing) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp),
-            horizontalArrangement = Arrangement.Center
-        ) {
-            CircularProgressIndicator()
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            PhotoThumbnail(
+                uriString = uriString,
+                contentDescription = contentDescription,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+                    .clip(RoundedCornerShape(12.dp))
+            )
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onCapture,
+                enabled = !isCapturing,
+                contentPadding = PaddingValues(vertical = 12.dp)
+            ) {
+                Text(text = "Prendre")
+            }
+            OutlinedButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onClear,
+                enabled = uriString != null,
+                contentPadding = PaddingValues(vertical = 12.dp)
+            ) {
+                Text(text = "Effacer")
+            }
         }
     }
 }
@@ -190,11 +185,11 @@ private fun CaptureControls(
 private fun ResultSection(
     firstScores: ClarityEvaluation?,
     secondScores: ClarityEvaluation?,
-    firstBitmap: Bitmap?,
-    secondBitmap: Bitmap?
+    firstPhotoUri: String?,
+    secondPhotoUri: String?
 ) {
     if (firstScores == null && secondScores == null) {
-        Text(text = "Capture images to compare clarity", style = MaterialTheme.typography.bodyMedium)
+        Text(text = "Capturez deux images pour lancer la comparaison", style = MaterialTheme.typography.bodyMedium)
         return
     }
     Card(
@@ -203,39 +198,33 @@ private fun ResultSection(
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Text(text = "Clarity Results", style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
+            Text(text = "Résultat de la comparaison", style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
             val percentages = relativePercentage(firstScores, secondScores)
-            Text(text = "Clarity index: ${percentages.first}% vs ${percentages.second}%")
+            Text(text = "Indice de netteté : ${percentages.first}% / ${percentages.second}%")
             firstScores?.let {
-                Text(text = "First image method: ${methodLabel(it.method)}")
+                Text(text = "Photo A : ${methodLabel(it.method)}")
             }
             secondScores?.let {
-                Text(text = "Second image method: ${methodLabel(it.method)}")
+                Text(text = "Photo B : ${methodLabel(it.method)}")
             }
-            if (firstBitmap != null || secondBitmap != null) {
+            if (firstPhotoUri != null || secondPhotoUri != null) {
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    firstBitmap?.let {
-                        Image(
-                            bitmap = it.asImageBitmap(),
-                            contentDescription = "First capture",
-                            modifier = Modifier
-                                .weight(1f)
-                                .clip(RoundedCornerShape(12.dp))
-                                .height(160.dp),
-                            contentScale = ContentScale.Crop
-                        )
-                    }
-                    secondBitmap?.let {
-                        Image(
-                            bitmap = it.asImageBitmap(),
-                            contentDescription = "Second capture",
-                            modifier = Modifier
-                                .weight(1f)
-                                .clip(RoundedCornerShape(12.dp))
-                                .height(160.dp),
-                            contentScale = ContentScale.Crop
-                        )
-                    }
+                    PhotoThumbnail(
+                        uriString = firstPhotoUri,
+                        contentDescription = "Aperçu photo A",
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(160.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                    )
+                    PhotoThumbnail(
+                        uriString = secondPhotoUri,
+                        contentDescription = "Aperçu photo B",
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(160.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                    )
                 }
             }
         }
@@ -243,45 +232,60 @@ private fun ResultSection(
 }
 
 @Composable
-private fun ErrorMessage(error: String?) {
+private fun PhotoThumbnail(uriString: String?, contentDescription: String, modifier: Modifier = Modifier) {
+    val bitmap = rememberBitmapFromUri(uriString)
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = contentDescription,
+            modifier = modifier,
+            contentScale = ContentScale.Crop
+        )
+    } else {
+        Box(
+            modifier = modifier,
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "Aucune image", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun ErrorMessage(error: String?, onDismiss: () -> Unit) {
     if (error.isNullOrBlank()) return
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
     ) {
-        Text(
-            text = error,
+        Column(
             modifier = Modifier.padding(16.dp),
-            color = MaterialTheme.colorScheme.onErrorContainer
-        )
-    }
-}
-
-private suspend fun captureImage(
-    cameraState: CameraCaptureState,
-    onResult: (Uri, Bitmap) -> Unit,
-    onError: (String) -> Unit,
-    onStateChange: (Boolean) -> Unit
-) {
-    try {
-        onStateChange(true)
-        val capture = cameraState.captureBitmap()
-        if (capture != null) {
-            onResult(capture.uri, capture.bitmap)
-        } else {
-            onError("Unable to capture image data")
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            OutlinedButton(onClick = onDismiss) {
+                Text(text = "Fermer")
+            }
         }
-    } catch (error: Throwable) {
-        onError(error.message ?: "Failed to capture image")
-    } finally {
-        onStateChange(false)
     }
 }
 
-private fun evaluateClarity(bitmap: Bitmap): ClarityEvaluation {
-    val image = extractLuminance(bitmap)
-    return Clarity.clarityScore(image.width, image.height, image.luminance)
+@Composable
+private fun rememberBitmapFromUri(uriString: String?): Bitmap? {
+    val context = LocalContext.current
+    val state = produceState<Bitmap?>(initialValue = null, uriString) {
+        value = uriString?.let {
+            runCatching { loadBitmapFromUri(context, Uri.parse(it)) }.getOrNull()
+        }
+        awaitDispose {
+            value?.recycle()
+        }
+    }
+    return state.value
 }
 
 private fun relativePercentage(first: ClarityEvaluation?, second: ClarityEvaluation?): Pair<Int, Int> {
@@ -296,7 +300,27 @@ private fun relativePercentage(first: ClarityEvaluation?, second: ClarityEvaluat
 
 private fun methodLabel(method: ClarityMethod): String {
     return when (method) {
-        ClarityMethod.LAPLACIAN -> "Laplacian"
+        ClarityMethod.LAPLACIAN -> "Laplacien"
         ClarityMethod.TENENGRAD -> "Tenengrad"
+    }
+}
+
+private fun loadBitmapFromUri(context: Context, uri: Uri): Bitmap? {
+    val resolver = context.contentResolver
+    return resolver.openInputStream(uri)?.use { stream ->
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeStream(stream, null, options)
+        val maxDimension = 1024
+        var sampleSize = 1
+        while (
+            options.outWidth / sampleSize > maxDimension ||
+            options.outHeight / sampleSize > maxDimension
+        ) {
+            sampleSize *= 2
+        }
+        val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+        resolver.openInputStream(uri)?.use { decodeStream ->
+            BitmapFactory.decodeStream(decodeStream, null, decodeOptions)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- persist captured photo and clarity state with `rememberSaveable`, using stored URI strings for rotation resilience
- reload thumbnails from disk on demand and delete saved files when a slot is cleared
- gate the comparison action until both captures and evaluations survive configuration changes

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK not installed in the execution environment)*
- `./gradlew :app:lintDebug` *(fails: Android SDK not installed in the execution environment)*
- `./gradlew :imagequality:testDebugUnitTest`

------
https://chatgpt.com/codex/tasks/task_e_68de76752ec4832eb71e4ca470256c85