### PR TITLE
chore: update activity compose dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
-    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.activity:activity-compose:1.11.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
 
     implementation("androidx.camera:camera-core:1.5.0")


### PR DESCRIPTION
## Summary
- bump `androidx.activity:activity-compose` to version 1.11.0
- refresh Gradle dependencies to pull the updated artifacts

## Testing
- `./gradlew --refresh-dependencies`
- `./gradlew :app:assembleDebug :app:lintDebug :app:testDebugUnitTest :imagequality:testDebugUnitTest` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de80dea52c832ea88879d68875af38