### PR TITLE
feat: reuse shared clarity percentage helper

### DIFF
--- a/app/src/main/java/com/photo/clarity/MainActivity.kt
+++ b/app/src/main/java/com/photo/clarity/MainActivity.kt
@@ -47,13 +47,13 @@ import com.photo.clarity.PhotoSlot
 import com.rochias.clarity.camera.CameraCaptureState
 import com.rochias.clarity.camera.CameraPreview
 import com.rochias.clarity.camera.rememberCameraCaptureState
+import com.rochias.clarity.iq.Clarity
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import kotlin.math.max
-import kotlin.math.roundToInt
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -257,14 +257,8 @@ private fun calculateClarity(bitmapA: Bitmap, bitmapB: Bitmap): ClarityResult {
     val useFallback = varianceA <= 1e-6 && varianceB <= 1e-6
     val scoreA = if (useFallback) tenengrad(bitmapA) else varianceA
     val scoreB = if (useFallback) tenengrad(bitmapB) else varianceB
-    val total = scoreA + scoreB
-    return if (total <= 0.0) {
-        ClarityResult(50, 50)
-    } else {
-        val rawPercentA = ((scoreA / total) * 100.0).roundToInt().coerceIn(0, 100)
-        val percentB = (100 - rawPercentA).coerceIn(0, 100)
-        ClarityResult(rawPercentA, percentB)
-    }
+    val (percentA, percentB) = Clarity.relativePercentages(scoreA, scoreB)
+    return ClarityResult(percentA, percentB)
 }
 
 private fun varianceOfLaplacian(bitmap: Bitmap): Double {

--- a/imagequality/src/main/java/com/rochias/clarity/iq/Clarity.kt
+++ b/imagequality/src/main/java/com/rochias/clarity/iq/Clarity.kt
@@ -1,5 +1,6 @@
 package com.rochias.clarity.iq
 
+import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
 enum class ClarityMethod {
@@ -53,6 +54,18 @@ object Clarity {
         }
         val tenengradValue = sanitizeScore(tenengrad(width, height, luminance))
         return ClarityEvaluation(tenengradValue, ClarityMethod.TENENGRAD, laplacianValue, tenengradValue)
+    }
+
+    fun relativePercentages(scoreA: Double, scoreB: Double): Pair<Int, Int> {
+        val sanitizedA = sanitizeScore(scoreA)
+        val sanitizedB = sanitizeScore(scoreB)
+        val total = sanitizedA + sanitizedB
+        if (total <= 0.0) {
+            return 50 to 50
+        }
+        val percentA = ((sanitizedA / total) * 100.0).roundToInt().coerceIn(0, 100)
+        val percentB = (100 - percentA).coerceIn(0, 100)
+        return percentA to percentB
     }
 
     private inline fun varianceOfLaplacian(width: Int, height: Int, accessor: (Int) -> Int): Double {

--- a/imagequality/src/test/java/com/rochias/clarity/iq/ClarityTest.kt
+++ b/imagequality/src/test/java/com/rochias/clarity/iq/ClarityTest.kt
@@ -60,6 +60,32 @@ class ClarityTest {
         assertTrue((subtleScore.tenengradScore ?: 0.0) > 0.0)
     }
 
+    @Test
+    fun relativePercentagesSumToOneHundred() {
+        val cases = listOf(
+            0.0 to 0.0,
+            10.0 to 30.0,
+            0.0 to 5.0,
+            100.0 to 0.0,
+            1_000_000.0 to 1.0,
+            Double.NaN to 40.0,
+            -5.0 to 15.0
+        )
+        cases.forEach { (first, second) ->
+            val (percentA, percentB) = Clarity.relativePercentages(first, second)
+            assertEquals(100, percentA + percentB)
+            assertTrue(percentA in 0..100)
+            assertTrue(percentB in 0..100)
+        }
+    }
+
+    @Test
+    fun relativePercentagesAreBalancedForEqualScores() {
+        val (percentA, percentB) = Clarity.relativePercentages(42.5, 42.5)
+        assertEquals(50, percentA)
+        assertEquals(50, percentB)
+    }
+
     private fun generatePattern(width: Int, height: Int, block: (Int, Int) -> Int): IntArray {
         val buffer = IntArray(width * height)
         for (y in 0 until height) {


### PR DESCRIPTION
## Summary
- add a reusable `relativePercentages` helper to the `Clarity` object
- refactor the app layer to call the shared helper when building UI percentages
- extend the imagequality unit suite with percentage normalization cases

## Testing
- ./gradlew :imagequality:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68deb24eb374832e816046f99fe51065