### PR TITLE
Add debug APK artifact upload to Android CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -43,3 +43,9 @@ jobs:
 
       - name: Build and Test
         run: ./gradlew clean :app:assembleDebug :app:lintDebug :app:testDebugUnitTest :imagequality:testDebugUnitTest
+
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary
- upload the assembled debug APK as an artifact in the Android CI workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68deb3baf8a4832e9a58fbc37ae22830