### PR TITLE
chore: align sdk configuration with api 35

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Accept licenses
         run: yes | sdkmanager --licenses
 
-      - name: Install Android packages (API 36, fallback 35 si indispo)
+      - name: Install Android packages (API 35)
         run: |
           sdkmanager --install "platform-tools" "cmdline-tools;latest"
-          sdkmanager --install "platforms;android-36" || sdkmanager --install "platforms;android-35"
-          sdkmanager --install "build-tools;36.0.0" || sdkmanager --install "build-tools;35.0.0"
+          sdkmanager --install "platforms;android-35"
+          sdkmanager --install "build-tools;35.0.0"
 
       # Génère le wrapper à partir de la distrib officielle Gradle (aucun binaire committé)
       - name: Generate Gradle Wrapper (no binary in git)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.photo.clarity"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.photo.clarity"
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
## Summary
- align the app module compile and target SDK levels with the available API 35
- update the Android CI workflow to install the Android 35 platform and build tools explicitly

## Testing
- Not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68ded0236574832ea879992bbb6e9e71