### PR TITLE
test: align imagequality tests with junit

### DIFF
--- a/imagequality/build.gradle.kts
+++ b/imagequality/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
 
 dependencies {
     testImplementation(kotlin("test"))
+    testImplementation("junit:junit:4.13.2")
 }
 
 tasks.register("testDebugUnitTest") {

--- a/imagequality/src/test/java/com/rochias/clarity/iq/ClarityTest.kt
+++ b/imagequality/src/test/java/com/rochias/clarity/iq/ClarityTest.kt
@@ -1,9 +1,9 @@
 package com.rochias.clarity.iq
 
 import kotlin.math.abs
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 class ClarityTest {
     @Test


### PR DESCRIPTION
## Summary
- add the JUnit 4.13.2 dependency to the imagequality module
- update Clarity unit tests to use org.junit imports

## Testing
- gradle/wrapper/gradle-8.13/bin/gradle --console=plain :imagequality:testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68ded29ab090832eb7d9cc13be7b42f8