### PR TITLE
chore: add roundToInt import

### DIFF
--- a/app/src/main/java/com/photo/clarity/MainActivity.kt
+++ b/app/src/main/java/com/photo/clarity/MainActivity.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import kotlin.math.max
+import kotlin.math.roundToInt
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary
- add the kotlin.math.roundToInt import to MainActivity alongside the other math utilities

## Testing
- ./gradlew :app:assembleDebug *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68dedb02b7a4832e89fe82855af3fb2a