### PR TITLE
feat: support gallery import fallback when camera denied

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="photo_short_label_a">A</string>
     <string name="photo_short_label_b">B</string>
     <string name="take_button">Prendre</string>
+    <string name="import_button">Importer</string>
     <string name="clear_button">Effacer</string>
     <string name="compare_button">Comparer</string>
     <string name="compare_in_progress">Analyse en cours…</string>
@@ -22,4 +23,6 @@
     <string name="camera_cancel_button">Annuler</string>
     <string name="camera_capture_button">Capturer</string>
     <string name="camera_capture_failed">La capture a échoué.</string>
+    <string name="camera_permission_denied_message">Permission caméra refusée. Importez une image.</string>
+    <string name="import_failed">L’import a échoué.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a gallery picker launcher in MainActivity to persist URIs per slot and reuse the clarity pipeline
- extend CompareScreen with import actions, permission-denied handling, and updated button states
- add French strings for the new import flow and error messaging

## Testing
- ⚠️ `./gradlew :app:assembleDebug` *(fails: gradle-wrapper.jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd013e000832eb542a5d7a6ac87fc