### PR TITLE
chore: align imagequality module toolchain with jdk 17

### DIFF
--- a/imagequality/build.gradle.kts
+++ b/imagequality/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(17)
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 


### PR DESCRIPTION
## Summary
- align the imagequality module Kotlin toolchain and JVM target with Java 17 to match the rest of the project

## Testing
- ./gradlew :imagequality:testDebugUnitTest *(fails: gradle-wrapper.jar missing in repository)*
- ./gradlew build *(fails: gradle-wrapper.jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e01f95bab0832e974d0524b8984290